### PR TITLE
Configure Vite base for GitHub Pages

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 
-const repository = process.env.GITHUB_REPOSITORY?.split('/')?.pop() ?? '';
-
 export default defineConfig({
   root: resolve(__dirname, '.'),
-  base: repository ? `/${repository}/` : '/',
+  base: process.env.GITHUB_REPOSITORY ? `/${process.env.GITHUB_REPOSITORY.split('/')[1]}/` : '/',
   server: {
     port: 4173,
     host: '0.0.0.0'


### PR DESCRIPTION
## Summary
- set the Vite base path to resolve correctly when deployed under the repository subdirectory

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6903508c24a88328b55f260d95057390