### PR TITLE
Update dependency installation logic in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,12 @@ jobs:
           node-version: 20
 
       - name: Install deps
-        run: npm ci
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary
- update the GitHub Pages workflow to check for a package-lock before running npm ci
- fall back to npm install with audit and fund checks disabled when no lockfile is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690354140dfc8328abb564ea6e20e15d