### PR TITLE
Configure Vite base path for Pages

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: process.env.GITHUB_REPOSITORY ? `/${process.env.GITHUB_REPOSITORY.split('/')[1]}/` : '/',
+});


### PR DESCRIPTION
## Summary
- add a Vite configuration that sets the `base` path dynamically for GitHub Pages deployments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69035dafd6d0832893530d3e2e7431fa