### PR TITLE
Fix GitHub Pages listing to use data-prefixed artifact paths

### DIFF
--- a/docs/data/index.json
+++ b/docs/data/index.json
@@ -3,17 +3,17 @@
     {
       "title": "Огни Сантьяго / Сторигейм / КвестБук",
       "source_url": "https://quest-book.ru/online/game17030/",
-      "path": ""
+      "path": "data/story-20251030T155355Z"
     },
     {
       "title": "Неостановимая / Сторигейм / КвестБук",
       "source_url": "https://quest-book.ru/online/dontstop/",
-      "path": ""
+      "path": "data/story-20251030T145414Z"
     },
     {
       "title": "Неостановимая / Сторигейм / КвестБук",
       "source_url": "https://quest-book.ru/online/dontstop/",
-      "path": ""
+      "path": "data/story-20251030T132612Z"
     },
     {
       "title": "Неостановимая / Сторигейм / КвестБук",

--- a/docs/main.js
+++ b/docs/main.js
@@ -50,10 +50,14 @@ async function loadIndex() {
       return;
     }
     const ul = document.createElement('ul');
+    let added = 0;
     data.items.slice(0, 50).forEach((item) => {
-      const li = document.createElement('li');
       const base = normalisePath(item.path);
-      const prefix = base ? `${base}/` : '';
+      if (!base) {
+        return;
+      }
+      const prefix = base.endsWith('/') ? base : `${base}/`;
+      const li = document.createElement('li');
       const title = document.createElement('strong');
       title.textContent = item.title || 'Без названия';
       const src = document.createElement('a');
@@ -90,7 +94,12 @@ async function loadIndex() {
         jsonUiLink,
       );
       ul.appendChild(li);
+      added += 1;
     });
+    if (!added) {
+      $('#list').textContent = 'Нет выгрузок.';
+      return;
+    }
     $('#list').innerHTML = '';
     $('#list').appendChild(ul);
   } catch (error) {


### PR DESCRIPTION
## Summary
- skip entries without a valid artifact directory when building the GitHub Pages list
- point existing scrape records to their data/ story folders so the links resolve

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6904361aec6883289a5a3352804b2c0e